### PR TITLE
Add a "HttpRequestRedactor" trait that allows pluggable request obfuscation when its "toString" is called

### DIFF
--- a/spray-http/src/main/scala/spray/http/HttpMessage.scala
+++ b/spray-http/src/main/scala/spray/http/HttpMessage.scala
@@ -21,6 +21,8 @@ import scala.reflect.{ classTag, ClassTag }
 import HttpHeaders._
 import HttpCharsets._
 
+import scala.runtime.ScalaRunTime
+
 sealed trait HttpMessagePartWrapper {
   def messagePart: HttpMessagePart
   def ack: Option[Any]
@@ -155,6 +157,15 @@ case class HttpRequest(method: HttpMethod = HttpMethods.GET,
   def message = this
   def isRequest = true
   def isResponse = false
+
+
+  /** Returns a redacted version of the request as a string
+    * @see HttpRequestRedactor
+    */
+  override def toString: String = {
+    val redacted = HttpRequestRedactor.redact(this)
+    ScalaRunTime._toString(redacted)
+  }
 
   def withEffectiveUri(securedConnection: Boolean, defaultHostHeader: Host = Host.empty): HttpRequest = {
     val hostHeader = header[Host]

--- a/spray-http/src/main/scala/spray/http/HttpMessage.scala
+++ b/spray-http/src/main/scala/spray/http/HttpMessage.scala
@@ -162,7 +162,7 @@ case class HttpRequest(method: HttpMethod = HttpMethods.GET,
   /** Returns a redacted version of the request as a string
     * @see HttpRequestRedactor
     */
-  override def toString: String = {
+  override final def toString: String = {
     val redacted = HttpRequestRedactor.redact(this)
     ScalaRunTime._toString(redacted)
   }

--- a/spray-http/src/main/scala/spray/http/HttpRequestRedactor.scala
+++ b/spray-http/src/main/scala/spray/http/HttpRequestRedactor.scala
@@ -5,6 +5,10 @@ trait HttpRequestRedactor {
   def redact(req: HttpRequest): HttpRequest
 }
 
+/**
+  * A global set of request redactors. This mutable set allows every component of an application to register
+  * redactors that filter out what's relevant to them.
+  */
 object HttpRequestRedactor {
   private var redactors = Set.empty[HttpRequestRedactor]
 
@@ -14,5 +18,10 @@ object HttpRequestRedactor {
 
   def redact(request: HttpRequest): HttpRequest = {
     redactors.foldLeft(request)((req, redactor) ⇒ redactor.redact(req))
+  }
+
+  /** Clears the redactors that have been registered. Use with care, meant to be used in tests. */
+  def clear(): Unit = this.synchronized {
+    redactors = Set.empty
   }
 }

--- a/spray-http/src/main/scala/spray/http/HttpRequestRedactor.scala
+++ b/spray-http/src/main/scala/spray/http/HttpRequestRedactor.scala
@@ -1,0 +1,18 @@
+package spray.http
+
+/** Removes sensitive data from a request prior to outputting it e.g. in logs */
+trait HttpRequestRedactor {
+  def redact(req: HttpRequest): HttpRequest
+}
+
+object HttpRequestRedactor {
+  private var redactors = Set.empty[HttpRequestRedactor]
+
+  def add(r: HttpRequestRedactor): Unit = this.synchronized {
+    redactors += r
+  }
+
+  def redact(request: HttpRequest): HttpRequest = {
+    redactors.foldLeft(request)((req, redactor) ⇒ redactor.redact(req))
+  }
+}

--- a/spray-http/src/test/scala/spray/http/HttpRequestRedactorSpec.scala
+++ b/spray-http/src/test/scala/spray/http/HttpRequestRedactorSpec.scala
@@ -1,0 +1,29 @@
+package spray.http
+
+import org.specs2.mutable.Specification
+
+class HttpRequestRedactorSpec extends Specification {
+
+  "HttpRequestRedactor" should {
+    "redact sensitive information" in {
+
+      HttpRequestRedactor.add(SampleHttpRedactor)
+
+      val r = HttpRequest(headers = List(
+        HttpHeaders.RawHeader("foo", "bar"),
+        HttpHeaders.RawHeader("x-something", "x-value")))
+
+      val toStr = r.toString
+
+      toStr must contain("foo")
+      toStr must contain("bar")
+      toStr.contains("x-something") mustEqual false
+    }
+  }
+}
+
+object SampleHttpRedactor extends HttpRequestRedactor {
+  override def redact(req: HttpRequest): HttpRequest = {
+    req.copy(headers = req.headers.filterNot(h ⇒ h.name.startsWith("x-")))
+  }
+}


### PR DESCRIPTION
Request objects can contain sensitive information like authentication headers. Currently `HttpRequest.toString` blindly outputs all fields (including headers), which can lead this information to end up in logs.

This PR adds a `HttpRequestRedactor` that allows registering a set of request transformers that will be called to redact sensitive information from requests when `toString` is called.