### PR TITLE
Allow extending the http pipeline

### DIFF
--- a/spray-can/src/main/scala/spray/can/server/HttpListener.scala
+++ b/spray-can/src/main/scala/spray/can/server/HttpListener.scala
@@ -33,7 +33,7 @@ private[can] class HttpListener(bindCommander: ActorRef,
   private val connectionCounter = Iterator from 0
   private val settings = bind.settings getOrElse ServerSettings(system)
   private val statsHolder = if (settings.statsSupport) Some(new StatsHolder) else None
-  private val pipelineStage = HttpServerConnection.pipelineStage(settings, statsHolder)
+  private val pipelineStage = bind.setupPipeline(HttpServerConnection.pipelineStage(settings, statsHolder))
 
   context.watch(listener)
 

--- a/spray-can/src/main/scala/spray/can/server/ServerFrontend.scala
+++ b/spray-can/src/main/scala/spray/can/server/ServerFrontend.scala
@@ -29,7 +29,7 @@ import spray.io._
 import spray.util.Timestamp
 import akka.io.Tcp.NoAck
 
-private object ServerFrontend {
+object ServerFrontend {
 
   trait Context extends PipelineContext {
     // the application-level request handler


### PR DESCRIPTION
This PR adds to the `http.Bind` message a function that allows extending the http pipeline. This function receives the standard pipeline and returns a possibly modified one.

Our main use case is adding support for the [HAProxy proxy protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) in situations where a front-end load balancer is not able to pass the common `X-Forwarded-For` headers.