### PR TITLE
Add attributes to RequestContext

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -123,6 +123,7 @@ object Build extends Build {
         "spray.io.*;resolution:=optional"
       )): _*)
       .settings(libraryDependencies ++= provided(akkaActor))
+      .settings(libraryDependencies ++= Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value))
 
   lazy val sprayRouting =
     sprayRoutingProject("spray-routing", file("spray-routing"))

--- a/spray-httpx/src/main/scala/spray/httpx/marshalling/BasicToResponseMarshallers.scala
+++ b/spray-httpx/src/main/scala/spray/httpx/marshalling/BasicToResponseMarshallers.scala
@@ -3,6 +3,7 @@ package spray.httpx.marshalling
 import spray.http._
 import spray.http.HttpResponse
 import akka.actor.ActorRef
+import spray.util.ContextAttributes
 
 trait BasicToResponseMarshallers {
   implicit def fromResponse: ToResponseMarshaller[HttpResponse] = ToResponseMarshaller((value, ctx) ⇒ ctx.marshalTo(value))
@@ -31,6 +32,8 @@ trait BasicToResponseMarshallers {
           def rejectMarshalling(supported: Seq[ContentType]): Unit = ctx.rejectMarshalling(supported)
           def startChunkedMessage(entity: HttpEntity, ack: Option[Any], hs: Seq[HttpHeader])(implicit sender: ActorRef): ActorRef =
             ctx.startChunkedMessage(HttpResponse(status, entity, (headers ++ hs).toList), ack)
+
+          override val attributes: ContextAttributes = ctx.attributes
         }
         tMarshaller(value._3, mCtx)
       }

--- a/spray-httpx/src/main/scala/spray/httpx/marshalling/CollectingMarshallingContext.scala
+++ b/spray-httpx/src/main/scala/spray/httpx/marshalling/CollectingMarshallingContext.scala
@@ -19,17 +19,19 @@ package spray.httpx.marshalling
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit._
+
 import scala.annotation.tailrec
 import akka.spray.UnregisteredActorRef
 import akka.util.Timeout
-import akka.actor.{ ActorRefFactory, ActorRef }
+import akka.actor.{ ActorRef, ActorRefFactory }
 import spray.http._
+import spray.util.ContextAttributes
 
 /**
  * A MarshallingContext serving as a marshalling receptacle, collecting the output of a Marshaller
  * for subsequent postprocessing.
  */
-class CollectingMarshallingContext(implicit actorRefFactory: ActorRefFactory = null) extends MarshallingContext {
+class CollectingMarshallingContext(implicit actorRefFactory: ActorRefFactory = null, val attributes: ContextAttributes = ContextAttributes.empty) extends MarshallingContext {
   private val _entityAndHeaders = new AtomicReference[Option[(HttpEntity, Seq[HttpHeader])]](None)
   private val _error = new AtomicReference[Option[Throwable]](None)
   private val _chunkedMessageEnd = new AtomicReference[Option[ChunkedMessageEnd]](None)

--- a/spray-httpx/src/main/scala/spray/httpx/marshalling/Marshaller.scala
+++ b/spray-httpx/src/main/scala/spray/httpx/marshalling/Marshaller.scala
@@ -19,8 +19,7 @@ package spray.httpx.marshalling
 import scala.util.control.NonFatal
 import akka.actor.ActorRef
 import spray.http._
-
-import scala.reflect.runtime.universe
+import spray.util.ContextAttributes
 
 //# source-quote
 trait Marshaller[-T] {
@@ -110,6 +109,8 @@ object ToResponseMarshaller extends BasicToResponseMarshallers
             def handleError(error: Throwable): Unit = ctx.handleError(error)
             def startChunkedMessage(response: HttpResponse, ack: Option[Any])(implicit sender: ActorRef): ActorRef =
               ctx.startChunkedMessage(response, ack)(sender)
+
+            override val attributes: ContextAttributes = ctx.attributes
           })
         case Nil ⇒ ctx.rejectMarshalling(previouslySupported.toSeq)
       }

--- a/spray-httpx/src/main/scala/spray/httpx/marshalling/Marshaller.scala
+++ b/spray-httpx/src/main/scala/spray/httpx/marshalling/Marshaller.scala
@@ -20,6 +20,8 @@ import scala.util.control.NonFatal
 import akka.actor.ActorRef
 import spray.http._
 
+import scala.reflect.runtime.universe
+
 //# source-quote
 trait Marshaller[-T] {
   def apply(value: T, ctx: MarshallingContext)

--- a/spray-httpx/src/main/scala/spray/httpx/marshalling/MarshallingContext.scala
+++ b/spray-httpx/src/main/scala/spray/httpx/marshalling/MarshallingContext.scala
@@ -18,6 +18,7 @@ package spray.httpx.marshalling
 
 import akka.actor.ActorRef
 import spray.http._
+import spray.util.ContextAttributes
 
 trait MarshallingContext {
 
@@ -87,6 +88,8 @@ trait MarshallingContext {
       override def startChunkedMessage(entity: HttpEntity, ack: Option[Any], headers: Seq[HttpHeader])(implicit sender: ActorRef) =
         underlying.startChunkedMessage(f(entity), ack, headers)
     }
+
+  val attributes: ContextAttributes
 }
 
 /**
@@ -94,12 +97,15 @@ trait MarshallingContext {
  * wraps another MarshallingContext with some extra logic.
  */
 class DelegatingMarshallingContext(protected val underlying: MarshallingContext) extends MarshallingContext {
+
   def tryAccept(contentTypes: Seq[ContentType]) = underlying.tryAccept(contentTypes)
   def rejectMarshalling(supported: Seq[ContentType]): Unit = underlying.rejectMarshalling(supported)
   def marshalTo(entity: HttpEntity, headers: HttpHeader*): Unit = underlying.marshalTo(entity, headers: _*)
   def handleError(error: Throwable): Unit = underlying.handleError(error)
   def startChunkedMessage(entity: HttpEntity, ack: Option[Any] = None, headers: Seq[HttpHeader] = Nil)(implicit sender: ActorRef) =
     underlying.startChunkedMessage(entity, ack, headers)
+
+  override val attributes: ContextAttributes = underlying.attributes
 }
 
 trait ToResponseMarshallingContext {
@@ -169,6 +175,8 @@ trait ToResponseMarshallingContext {
       override def startChunkedMessage(response: HttpResponse, ack: Option[Any])(implicit sender: ActorRef): ActorRef =
         underlying.startChunkedMessage(f(response), ack)
     }
+
+  val attributes: ContextAttributes
 }
 
 /**
@@ -183,4 +191,6 @@ class DelegatingToResponseMarshallingContext(protected val underlying: ToRespons
   def handleError(error: Throwable): Unit = underlying.handleError(error)
   def startChunkedMessage(response: HttpResponse, ack: Option[Any])(implicit sender: ActorRef): ActorRef =
     underlying.startChunkedMessage(response, ack)
+
+  override val attributes: ContextAttributes = underlying.attributes
 }

--- a/spray-routing/src/main/scala/spray/routing/RequestContext.scala
+++ b/spray-routing/src/main/scala/spray/routing/RequestContext.scala
@@ -33,18 +33,19 @@ import scala.reflect.runtime.universe._
  * Immutable object encapsulating the context of an [[spray.http.HttpRequest]]
  * as it flows through a ''spray'' Route structure.
  */
-case class RequestContext(request: HttpRequest, responder: ActorRef, unmatchedPath: Uri.Path, attributes: Map[TypeTag[_], Any]) {
+case class RequestContext(request: HttpRequest, responder: ActorRef, unmatchedPath: Uri.Path,
+                          attributes: Map[TypeTag[_], Any] = Map.empty) {
 
   /**
-    * Returns a copy of this context with a new attribute added.
-    */
+   * Returns a copy of this context with a new attribute added.
+   */
   def withAttribute[T](value: T)(implicit t: TypeTag[T]): RequestContext = {
     copy(attributes = attributes.updated(t, value))
   }
 
   /**
-    * Optionally get an attribute identified by its type.
-    */
+   * Optionally get an attribute identified by its type.
+   */
   def getAttribute[T](implicit t: TypeTag[T]): Option[T] = {
     attributes.get(t).asInstanceOf[Option[T]]
   }
@@ -239,7 +240,6 @@ case class RequestContext(request: HttpRequest, responder: ActorRef, unmatchedPa
    */
   def complete[T](obj: T)(implicit marshaller: ToResponseMarshaller[T]): Unit = {
     val ctx = new ToResponseMarshallingContext {
-      val attributes = this.attributes
       def tryAccept(contentTypes: Seq[ContentType]) = request.acceptableContentType(contentTypes)
       def rejectMarshalling(onlyTo: Seq[ContentType]): Unit = reject(UnacceptedResponseContentTypeRejection(onlyTo))
       def marshalTo(response: HttpResponse): Unit = responder ! response

--- a/spray-routing/src/main/scala/spray/routing/RequestContext.scala
+++ b/spray-routing/src/main/scala/spray/routing/RequestContext.scala
@@ -27,11 +27,27 @@ import StatusCodes._
 import HttpHeaders._
 import MediaTypes._
 
+import scala.reflect.runtime.universe._
+
 /**
  * Immutable object encapsulating the context of an [[spray.http.HttpRequest]]
  * as it flows through a ''spray'' Route structure.
  */
-case class RequestContext(request: HttpRequest, responder: ActorRef, unmatchedPath: Uri.Path) {
+case class RequestContext(request: HttpRequest, responder: ActorRef, unmatchedPath: Uri.Path, attributes: Map[TypeTag[_], Any]) {
+
+  /**
+    * Returns a copy of this context with a new attribute added.
+    */
+  def withAttribute[T](value: T)(implicit t: TypeTag[T]): RequestContext = {
+    copy(attributes = attributes.updated(t, value))
+  }
+
+  /**
+    * Optionally get an attribute identified by its type.
+    */
+  def getAttribute[T](implicit t: TypeTag[T]): Option[T] = {
+    attributes.get(t).asInstanceOf[Option[T]]
+  }
 
   /**
    * Returns a copy of this context with the HttpRequest transformed by the given function.
@@ -223,6 +239,7 @@ case class RequestContext(request: HttpRequest, responder: ActorRef, unmatchedPa
    */
   def complete[T](obj: T)(implicit marshaller: ToResponseMarshaller[T]): Unit = {
     val ctx = new ToResponseMarshallingContext {
+      val attributes = this.attributes
       def tryAccept(contentTypes: Seq[ContentType]) = request.acceptableContentType(contentTypes)
       def rejectMarshalling(onlyTo: Seq[ContentType]): Unit = reject(UnacceptedResponseContentTypeRejection(onlyTo))
       def marshalTo(response: HttpResponse): Unit = responder ! response

--- a/spray-routing/src/main/scala/spray/routing/directives/CachingDirectives.scala
+++ b/spray-routing/src/main/scala/spray/routing/directives/CachingDirectives.scala
@@ -114,7 +114,7 @@ trait CacheKeyer extends (PartialFunction[RequestContext, Any])
 
 object CacheKeyer {
   implicit val Default: CacheKeyer = CacheKeyer {
-    case RequestContext(HttpRequest(GET, uri, _, _, _), _, _) ⇒ uri
+    case RequestContext(HttpRequest(GET, uri, _, _, _), _, _, attrs) if attrs.isEmpty ⇒ uri
   }
 
   def apply(f: PartialFunction[RequestContext, Any]) = new CacheKeyer {

--- a/spray-util/src/main/scala/spray/util/ContextAttributes.scala
+++ b/spray-util/src/main/scala/spray/util/ContextAttributes.scala
@@ -1,0 +1,32 @@
+package spray.util
+
+import scala.reflect.runtime.universe.TypeTag
+
+/**
+  * Class providing type keyed map used in contexts such as marshalling and request contexts.
+  */
+class ContextAttributes private (private val underlying: Map[TypeTag[_], Any]) extends AnyVal {
+
+  /**
+    * Provides a copy of the map with the value `value` at key `t`
+    * @param t Type tag used as key to store the new value.
+    * @param value Valued stored as the entry for `t`
+    * @return A new map with the entry (`t`, `value`)
+    */
+  def updated[T](value: T)(implicit t: TypeTag[T]): ContextAttributes =
+    new ContextAttributes(underlying.updated(t, value))
+
+  /**
+    * Provides the element for key `t` if present in the map, `None` otherwise.
+    *
+    * @param t Query key as a [[TypeTag]]
+    * @return The stored value for `t` wrapped by [[Some]] if present, [[None]] otherwise
+    */
+  def get[T](implicit t: TypeTag[T]): Option[T] = underlying.get(t).map(_.asInstanceOf[T])
+
+  def isEmpty: Boolean = underlying.isEmpty
+}
+
+object ContextAttributes {
+  val empty: ContextAttributes = new ContextAttributes(Map.empty)
+}

--- a/spray-util/src/test/scala/spray/util/ContextAttributesSpec.scala
+++ b/spray-util/src/test/scala/spray/util/ContextAttributesSpec.scala
@@ -1,0 +1,39 @@
+package spray.util
+
+import org.specs2.mutable.Specification
+
+class ContextAttributesSpec extends Specification {
+
+  "ContextAttributes" should {
+    "should be able to store values" in {
+      val empty = ContextAttributes.empty
+      empty.isEmpty === true
+
+      val withInteger = empty.updated(42)
+      withInteger.isEmpty === false
+      withInteger.get[Int] === Some(42)
+
+      val strExample: String = "meaning of life universe and everything"
+
+      val withStringAndInteger = withInteger.updated(strExample)
+      withStringAndInteger.get[Int] === Some(42)
+      withStringAndInteger.get[String] === Some(strExample)
+    }
+
+    "should be able to store parametrized types" in {
+      val empty = ContextAttributes.empty
+      empty.isEmpty === true
+
+      val intList: List[Int] = List(42)
+      val withIntegerList = empty.updated(intList)
+      withIntegerList.isEmpty === false
+      withIntegerList.get[List[Int]] === Some(intList)
+
+      val strList: List[String] = List("meaning of life universe and everything")
+      val withStringAndInteger = withIntegerList.updated(strList)
+      withStringAndInteger.get[List[Int]] === Some(intList)
+      withStringAndInteger.get[List[String]] === Some(strList)
+    }
+  }
+
+}


### PR DESCRIPTION
Adds a map of (type -> value of type) attributes to request context, so that contextual information can be passed down the routing tree.