### PR TITLE
Add optional throwable parameter to `ConnectionException`s

### DIFF
--- a/spray-can/src/main/scala/spray/can/Http.scala
+++ b/spray-can/src/main/scala/spray/can/Http.scala
@@ -134,9 +134,9 @@ object Http extends ExtensionKey[HttpExt] {
   case class HostConnectorInfo(hostConnector: ActorRef, setup: HostConnectorSetup) extends Event
 
   // exceptions
-  class ConnectionException(message: String) extends RuntimeException(message)
+  class ConnectionException(message: String, cause: Throwable = null) extends RuntimeException(message, cause)
 
-  class ConnectionAttemptFailedException(val host: String, val port: Int) extends ConnectionException(s"Connection attempt to $host:$port failed")
+  class ConnectionAttemptFailedException(val host: String, val port: Int, cause: Throwable = null) extends ConnectionException(s"Connection attempt to $host:$port failed", cause)
 
   class RequestTimeoutException(val request: HttpRequestPart with HttpMessageStart, message: String)
     extends ConnectionException(message)


### PR DESCRIPTION
Add optional throwable parameter to `ConnectionException` and `ConnectionAttemptFailedException`

I've added this parameter in order to not swallow the original exceptions in the case of a host not being reachable. See this comment: https://github.com/elastic/cloud/pull/26262#discussion_r251132634

**Question**:  Do I have to manually rev the spray version in `BuildSettings.scala` or does that happen automatically with the release manager?  